### PR TITLE
Configfigured development email server

### DIFF
--- a/compose/mailpit/docker-compose.yml
+++ b/compose/mailpit/docker-compose.yml
@@ -1,0 +1,6 @@
+services:
+  mailpit:
+    image: axllent/mailpit
+    ports:
+      - "1025:1025"
+      - "8025:8025"

--- a/config/email.json
+++ b/config/email.json
@@ -1,0 +1,23 @@
+{
+  "development": {
+    "host": "localhost",
+    "port": 1025,
+    "secure": false
+  },
+
+  "test": {
+    "host": "localhost",
+    "port": 1025,
+    "secure": false
+  },
+
+  "production": {
+    "host": "mail.example.com",
+    "port": 465,
+    "secure": true,
+    "auth": {
+      "user": "noreply@example.com",
+      "pass": null
+    }
+  }
+}

--- a/email/templates/send_otp.ejs
+++ b/email/templates/send_otp.ejs
@@ -1,0 +1,19 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Verify Your Email</title>
+</head>
+<body>
+    <p>Hello <%= name %>,</p>
+
+    <p>Your One-Time Password (OTP) to verify your email for simple-gst-app is: <strong><%= otp %></strong></p>
+
+    <p>Use this OTP to complete your email verification. Do not share it with anyone.</p>
+
+    <p>If you didn’t request this, you can ignore this email.</p>
+
+    <p>Best,<br>simple-gst-app Team</p>
+</body>
+</html>


### PR DESCRIPTION
Used **Mailpit** (https://mailpit.axllent.org/) as the development email server.

When a new user is created, an email with an OTP is automatically sent. **Manually tested**, and it works (at least on my machine, lol).  

## How to start the email server  

To start the email server, go to */compose/mailpit* and run `docker-compose up -d`. This will start Mailpit with an SMTP server on port `1025` and a GUI front end on port `8025`.  

Go to [http://localhost:8025](http://localhost:8025) to access the GUI, where you can view all sent emails.